### PR TITLE
use go-libp2p-core/peer instead of go-libp2p-peer

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
-	peer "github.com/libp2p/go-libp2p-peer"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 var blockGenerator = blocksutil.NewBlockGenerator()


### PR DESCRIPTION
This makes `staticcheck` happy and would allow us to onboard this repo to the Unified CI Setup.